### PR TITLE
Optimisation: Reduce parsing of JSON object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 /.swiftpm
 /Packages
 /*.xcodeproj
+/docs
 xcuserdata/
 Package.resolved

--- a/Sources/JMESPath/Ast.swift
+++ b/Sources/JMESPath/Ast.swift
@@ -1,31 +1,44 @@
-//
-//  File.swift
-//
-//
-//  Created by Adam Fowler on 27/05/2021.
-//
-
+/// JMES expression abstract syntax tree
 public indirect enum Ast: Equatable {
+    /// compares two nodes using a comparator
     case comparison(comparator: Comparator, lhs: Ast, rhs: Ast)
+    /// if `predicate` evaluates to a truthy value returns result from `then`
     case condition(predicate: Ast, then: Ast)
+    /// returns the current node
     case identity
+    /// used by functions to dynamically evaluate argument values
     case expRef(ast: Ast)
+    /// evaluates nodes and then flattens it one level
     case flatten(node: Ast)
+    /// function name and a vector of function argument expressions
     case function(name: String, args: [Ast])
+    /// extracts a key value from an object
     case field(name: String)
+    /// extracts an indexed value from an array
     case index(index: Int)
+    /// resolves to a literal value
     case literal(value: JMESVariable)
+    /// resolves to a list of evaluated expressions
     case multiList(elements: [Ast])
+    /// resolves to a map of key/evaluated expression pairs
     case multiHash(elements: [String: Ast])
+    /// evaluates to true/false based on expression
     case not(node: Ast)
+    /// evalutes `lhs` and pushes each value through to `rhs`
     case projection(lhs: Ast, rhs: Ast)
+    /// evaluates expression and if result is an object then return array of its values
     case objectValues(node: Ast)
+    /// evaluates `lhs` and if not truthy returns, otherwise evaluates `rhs`
     case and(lhs: Ast, rhs: Ast)
+    /// evaluates `lhs` and if truthy returns, otherwise evaluates `rhs`
     case or(lhs: Ast, rhs: Ast)
+    /// returns a slice of an array
     case slice(start: Int?, stop: Int?, step: Int)
+    /// evalutes `lhs` and then provides that value to `rhs`
     case subExpr(lhs: Ast, rhs: Ast)
 }
 
+/// Comparator used in comparison AST nodes
 public enum Comparator: Equatable {
     case equal
     case notEqual
@@ -34,6 +47,7 @@ public enum Comparator: Equatable {
     case greaterThan
     case greaterThanOrEqual
 
+    /// initialise `Comparator` from `Token`
     init(from token: Token) throws {
         switch token {
         case .equals: self = .equal

--- a/Sources/JMESPath/Error.swift
+++ b/Sources/JMESPath/Error.swift
@@ -3,9 +3,9 @@
 /// Provides two errors, compile time and run time errors
 public struct JMESPathError: Error, Equatable {
     /// Error that occurred while compiling JMESPath
-    public static func compileTime(_ message: String) -> Self { .init(value: .compileTime(message))}
+    public static func compileTime(_ message: String) -> Self { .init(value: .compileTime(message)) }
     /// Error that occurred while running a search
-    public static func runtime(_ message: String) -> Self { .init(value: .runtime(message))}
+    public static func runtime(_ message: String) -> Self { .init(value: .runtime(message)) }
 
     private enum Internal: Equatable {
         case compileTime(String)

--- a/Sources/JMESPath/Expression.swift
+++ b/Sources/JMESPath/Expression.swift
@@ -23,7 +23,7 @@ public struct Expression {
     /// - Throws: JMESPathError
     /// - Returns: Search result
     public func search<Value>(json: String, as: Value.Type = Value.self, runtime: JMESRuntime = .init()) throws -> Value? {
-        return try search(json: json, runtime: runtime) as? Value
+        return try self.search(json: json, runtime: runtime) as? Value
     }
 
     /// Search Swift type
@@ -35,7 +35,7 @@ public struct Expression {
     /// - Throws: JMESPathError
     /// - Returns: Search result
     public func search<Value>(_ any: Any, as: Value.Type = Value.self, runtime: JMESRuntime = .init()) throws -> Value? {
-        return try search(any, runtime: runtime) as? Value
+        return try self.search(any, runtime: runtime) as? Value
     }
 
     /// Search JSON

--- a/Sources/JMESPath/Functions.swift
+++ b/Sources/JMESPath/Functions.swift
@@ -231,7 +231,7 @@ struct MapFunction: Function {
     static func evaluate(args: [JMESVariable], runtime: JMESRuntime) throws -> JMESVariable {
         switch (args[0], args[1]) {
         case (.expRef(let ast), .array(let array)):
-            let results = try array.map { try runtime.interpret(JMESVariable(from: $0), ast: ast) }
+            let results = try array.map { try runtime.interpret(JMESVariable(from: $0), ast: ast).collapse() ?? NSNull() }
             return .array(results)
         default:
             preconditionFailure()
@@ -528,10 +528,10 @@ struct ToArrayFunction: Function {
     static var signature: FunctionSignature { .init(inputs: .any) }
     static func evaluate(args: [JMESVariable], runtime: JMESRuntime) -> JMESVariable {
         switch args[0] {
-        case .array(let array):
-            return .array(array)
+        case .array:
+            return args[0]
         default:
-            return .array([args[0]])
+            return .array([args[0].collapse() ?? NSNull()])
         }
     }
 }

--- a/Sources/JMESPath/Functions.swift
+++ b/Sources/JMESPath/Functions.swift
@@ -54,7 +54,8 @@ public struct FunctionSignature {
 
     func validateArgs(_ args: [JMESVariable]) throws {
         guard args.count == self.inputs.count ||
-            (args.count > self.inputs.count && self.varArg != nil) else {
+            (args.count > self.inputs.count && self.varArg != nil)
+        else {
             throw JMESPathError.runtime("Invalid number of arguments")
         }
 
@@ -81,6 +82,7 @@ public protocol Function {
     static func evaluate(args: [JMESVariable], runtime: JMESRuntime) throws -> JMESVariable
 }
 
+/// Protocl for JMESPath function that takes a single number
 protocol NumberFunction: Function {
     static func evaluate(_ number: NSNumber) -> JMESVariable
 }
@@ -97,6 +99,7 @@ extension NumberFunction {
     }
 }
 
+/// Protocl for JMESPath function that takes a single array
 protocol ArrayFunction: Function {
     static func evaluate(_ array: JMESArray) -> JMESVariable
 }
@@ -112,6 +115,8 @@ extension ArrayFunction {
         }
     }
 }
+
+// MARK: Functions
 
 struct AbsFunction: NumberFunction {
     static func evaluate(_ number: NSNumber) -> JMESVariable {
@@ -145,7 +150,7 @@ struct ContainsFunction: Function {
     static func evaluate(args: [JMESVariable], runtime: JMESRuntime) -> JMESVariable {
         switch (args[0], args[1]) {
         case (.array(let array), _):
-            let result = array.first { args[1] == JMESVariable(from: $0)} != nil
+            let result = array.first { args[1] == JMESVariable(from: $0) } != nil
             return .boolean(result)
 
         case (.string(let string), .string(let string2)):
@@ -491,7 +496,7 @@ struct SortByFunction: Function {
             }
             let values = [ValueAndSortKey(value: first, sortValue: firstSortValue)] + restOfTheValues
             let sorted = values.sorted(by: { $0.sortValue.compare(.lessThan, value: $1.sortValue) == true })
-            return .array(sorted.map { $0.value} )
+            return .array(sorted.map { $0.value })
         default:
             preconditionFailure()
         }
@@ -584,4 +589,3 @@ struct ValuesFunction: Function {
         }
     }
 }
-

--- a/Sources/JMESPath/Functions.swift
+++ b/Sources/JMESPath/Functions.swift
@@ -576,7 +576,7 @@ struct ValuesFunction: Function {
     static func evaluate(args: [JMESVariable], runtime: JMESRuntime) -> JMESVariable {
         switch args[0] {
         case .object(let object):
-            return .array(object.map { $0.value })
+            return .array(object.map { JMESVariable(from: $0.value) })
         default:
             preconditionFailure()
         }

--- a/Sources/JMESPath/Interpreter.swift
+++ b/Sources/JMESPath/Interpreter.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension JMESRuntime {
+    /// Interpret Ast given object to search
+    /// - Parameters:
+    ///   - data: Object to search
+    ///   - ast: AST of search
+    /// - Throws: JMESPathError.runtime
+    /// - Returns: Result of search
     func interpret(_ data: JMESVariable, ast: Ast) throws -> JMESVariable {
         switch ast {
         case .field(let name):

--- a/Sources/JMESPath/Interpreter.swift
+++ b/Sources/JMESPath/Interpreter.swift
@@ -1,3 +1,4 @@
+import Foundation
 
 extension JMESRuntime {
     func interpret(_ data: JMESVariable, ast: Ast) throws -> JMESVariable {
@@ -59,7 +60,7 @@ extension JMESRuntime {
             let subject = try self.interpret(data, ast: node)
             switch subject {
             case .object(let map):
-                return .array(map.values.map { $0 })
+                return .array(map.values.map { JMESVariable(from: $0) })
             default:
                 return .null
             }
@@ -109,10 +110,10 @@ extension JMESRuntime {
             if data == .null {
                 return .null
             }
-            var collected: [String: JMESVariable] = [:]
+            var collected: JMESObject = [:]
             for element in elements {
                 let valueResult = try self.interpret(data, ast: element.value)
-                collected[element.key] = valueResult
+                collected[element.key] = valueResult.collapse() ?? NSNull()
             }
             return .object(collected)
 

--- a/Sources/JMESPath/Lexer.swift
+++ b/Sources/JMESPath/Lexer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Lexer object
 ///
-/// Parses raw test to create an array of tokens
+/// Parses raw text to create an array of tokens
 class Lexer {
     var index: String.Index
     let text: String

--- a/Sources/JMESPath/Parser.swift
+++ b/Sources/JMESPath/Parser.swift
@@ -12,7 +12,7 @@ class Parser {
 
     func parse() throws -> Ast {
         let result = try self.expression(rbp: 0)
-        guard case .eof = peek() else {
+        guard case .eof = self.peek() else {
             throw JMESPathError.compileTime("Did you not parse the complete expression")
         }
         return result

--- a/Sources/JMESPath/Runtime.swift
+++ b/Sources/JMESPath/Runtime.swift
@@ -2,47 +2,50 @@
 ///
 /// Holds list of functions available to JMESPath expression
 public class JMESRuntime {
+    /// Initialize `JMESRuntime`
     public init() {
-        self.functions = [:]
-        self.registerBuiltInFunctions()
+        self.functions = Self.builtInFunctions
     }
 
-    public func registerFunction(_ name: String, function: Function.Type) {
+    /// Register new function with runtime
+    /// - Parameters:
+    ///   - name: Function name
+    ///   - function: Function object
+    public func registerFunction(_ name: String, function: JMESFunction.Type) {
         self.functions[name] = function
     }
 
-    func getFunction(_ name: String) -> Function.Type? {
+    func getFunction(_ name: String) -> JMESFunction.Type? {
         return self.functions[name]
     }
 
-    func registerBuiltInFunctions() {
-        self.registerFunction("abs", function: AbsFunction.self)
-        self.registerFunction("avg", function: AvgFunction.self)
-        self.registerFunction("ceil", function: CeilFunction.self)
-        self.registerFunction("contains", function: ContainsFunction.self)
-        self.registerFunction("ends_with", function: EndsWithFunction.self)
-        self.registerFunction("floor", function: FloorFunction.self)
-        self.registerFunction("join", function: JoinFunction.self)
-        self.registerFunction("keys", function: KeysFunction.self)
-        self.registerFunction("length", function: LengthFunction.self)
-        self.registerFunction("map", function: MapFunction.self)
-        self.registerFunction("max", function: MaxFunction.self)
-        self.registerFunction("max_by", function: MaxByFunction.self)
-        self.registerFunction("min", function: MinFunction.self)
-        self.registerFunction("min_by", function: MinByFunction.self)
-        self.registerFunction("merge", function: MergeFunction.self)
-        self.registerFunction("not_null", function: NotNullFunction.self)
-        self.registerFunction("reverse", function: ReverseFunction.self)
-        self.registerFunction("sort", function: SortFunction.self)
-        self.registerFunction("sort_by", function: SortByFunction.self)
-        self.registerFunction("starts_with", function: StartsWithFunction.self)
-        self.registerFunction("sum", function: SumFunction.self)
-        self.registerFunction("to_array", function: ToArrayFunction.self)
-        self.registerFunction("to_number", function: ToNumberFunction.self)
-        self.registerFunction("to_string", function: ToStringFunction.self)
-        self.registerFunction("type", function: TypeFunction.self)
-        self.registerFunction("values", function: ValuesFunction.self)
-    }
-
-    var functions: [String: Function.Type]
+    private var functions: [String: JMESFunction.Type]
+    private static var builtInFunctions: [String: JMESFunction.Type] = [
+        "abs": AbsFunction.self,
+        "avg": AvgFunction.self,
+        "ceil": CeilFunction.self,
+        "contains": ContainsFunction.self,
+        "ends_with": EndsWithFunction.self,
+        "floor": FloorFunction.self,
+        "join": JoinFunction.self,
+        "keys": KeysFunction.self,
+        "length": LengthFunction.self,
+        "map": MapFunction.self,
+        "max": MaxFunction.self,
+        "max_by": MaxByFunction.self,
+        "min": MinFunction.self,
+        "min_by": MinByFunction.self,
+        "merge": MergeFunction.self,
+        "not_null": NotNullFunction.self,
+        "reverse": ReverseFunction.self,
+        "sort": SortFunction.self,
+        "sort_by": SortByFunction.self,
+        "starts_with": StartsWithFunction.self,
+        "sum": SumFunction.self,
+        "to_array": ToArrayFunction.self,
+        "to_number": ToNumberFunction.self,
+        "to_string": ToStringFunction.self,
+        "type": TypeFunction.self,
+        "values": ValuesFunction.self,
+    ]
 }

--- a/Tests/JMESPathTests/ComplianceTests.swift
+++ b/Tests/JMESPathTests/ComplianceTests.swift
@@ -107,7 +107,7 @@ final class ComplianceTests: XCTestCase {
                     let data = try JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .sortedKeys])
                     return String(decoding: data, as: Unicode.UTF8.self)
                 }
-                //print(c.expression)
+                print(c.expression)
                 if let value = try expression.search(self.given.value) {
                     let valueData = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .sortedKeys])
                     let valueJson = String(decoding: valueData, as: Unicode.UTF8.self)
@@ -145,13 +145,13 @@ final class ComplianceTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let tests = try JSONDecoder().decode([ComplianceTest].self, from: data)
 
-        let date = Date()
-        for _ in 0..<100 {
+        //let date = Date()
+        //for _ in 0..<100 {
             for test in tests {
                 try test.run()
             }
-        }
-        print(-date.timeIntervalSinceNow)
+        //}
+        //print(-date.timeIntervalSinceNow)
     }
 
     func testBasic() throws {
@@ -216,5 +216,11 @@ final class ComplianceTests: XCTestCase {
 
     func testWildcards() throws {
         try self.testCompliance(name: "wildcard")
+    }
+    
+    func testIndividual() throws {
+        let expression = try Expression.compile("*[?[0] == `0`]")
+        let result = try expression.search(json: #"{"foo": [0, 1], "bar": [2, 3]}"#)
+        print(result ?? "nil")
     }
 }

--- a/Tests/JMESPathTests/ComplianceTests.swift
+++ b/Tests/JMESPathTests/ComplianceTests.swift
@@ -107,7 +107,6 @@ final class ComplianceTests: XCTestCase {
                     let data = try JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .sortedKeys])
                     return String(decoding: data, as: Unicode.UTF8.self)
                 }
-                print(c.expression)
                 if let value = try expression.search(self.given.value) {
                     let valueData = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .sortedKeys])
                     let valueJson = String(decoding: valueData, as: Unicode.UTF8.self)
@@ -145,13 +144,9 @@ final class ComplianceTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let tests = try JSONDecoder().decode([ComplianceTest].self, from: data)
 
-        //let date = Date()
-        //for _ in 0..<100 {
-            for test in tests {
-                try test.run()
-            }
-        //}
-        //print(-date.timeIntervalSinceNow)
+        for test in tests {
+            try test.run()
+        }
     }
 
     func testBasic() throws {

--- a/Tests/JMESPathTests/ComplianceTests.swift
+++ b/Tests/JMESPathTests/ComplianceTests.swift
@@ -107,6 +107,7 @@ final class ComplianceTests: XCTestCase {
                     let data = try JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .sortedKeys])
                     return String(decoding: data, as: Unicode.UTF8.self)
                 }
+                //print(c.expression)
                 if let value = try expression.search(self.given.value) {
                     let valueData = try JSONSerialization.data(withJSONObject: value, options: [.fragmentsAllowed, .sortedKeys])
                     let valueJson = String(decoding: valueData, as: Unicode.UTF8.self)
@@ -144,9 +145,13 @@ final class ComplianceTests: XCTestCase {
         let data = try Data(contentsOf: url)
         let tests = try JSONDecoder().decode([ComplianceTest].self, from: data)
 
-        for test in tests {
-            try test.run()
+        let date = Date()
+        for _ in 0..<100 {
+            for test in tests {
+                try test.run()
+            }
         }
+        print(-date.timeIntervalSinceNow)
     }
 
     func testBasic() throws {

--- a/Tests/JMESPathTests/ComplianceTests.swift
+++ b/Tests/JMESPathTests/ComplianceTests.swift
@@ -67,15 +67,15 @@ final class ComplianceTests: XCTestCase {
         func run() throws {
             for c in self.cases {
                 if let _ = c.bench {
-                    testBenchmark(c)
+                    self.testBenchmark(c)
                 } else if let error = c.error {
-                    testError(c, error: error)
+                    self.testError(c, error: error)
                 } else {
-                    testResult(c, result: c.result?.value)
+                    self.testResult(c, result: c.result?.value)
                 }
             }
         }
-        
+
         func testBenchmark(_ c: Case) {
             do {
                 let expression = try Expression.compile(c.expression)
@@ -102,7 +102,7 @@ final class ComplianceTests: XCTestCase {
         func testResult(_ c: Case, result: Any?) {
             do {
                 let expression = try Expression.compile(c.expression)
-                
+
                 let resultJson: String? = try result.map {
                     let data = try JSONSerialization.data(withJSONObject: $0, options: [.fragmentsAllowed, .sortedKeys])
                     return String(decoding: data, as: Unicode.UTF8.self)
@@ -118,7 +118,7 @@ final class ComplianceTests: XCTestCase {
                 XCTFail("\(error)")
             }
         }
-        
+
         func output(_ c: Case, expected: String?, result: String?) {
             if expected != result {
                 let data = try! JSONSerialization.data(withJSONObject: self.given.value, options: [.fragmentsAllowed, .sortedKeys])
@@ -130,7 +130,6 @@ final class ComplianceTests: XCTestCase {
                 print("Given: \(givenJson)")
                 print("Expected: \(expected ?? "nil")")
                 print("Result: \(result ?? "nil")")
-
             }
         }
     }
@@ -211,11 +210,5 @@ final class ComplianceTests: XCTestCase {
 
     func testWildcards() throws {
         try self.testCompliance(name: "wildcard")
-    }
-    
-    func testIndividual() throws {
-        let expression = try Expression.compile("*[?[0] == `0`]")
-        let result = try expression.search(json: #"{"foo": [0, 1], "bar": [2, 3]}"#)
-        print(result ?? "nil")
     }
 }

--- a/Tests/JMESPathTests/MirrorTests.swift
+++ b/Tests/JMESPathTests/MirrorTests.swift
@@ -35,7 +35,7 @@ final class MirrorTests: XCTestCase {
             let f: Float
             let b: Bool
         }
-        let test = TestNumbers(i:34, d: 1.4, f: 2.5, b: true)
+        let test = TestNumbers(i: 34, d: 1.4, f: 2.5, b: true)
         self.testInterpreter("i", data: test, result: 34)
         self.testInterpreter("d", data: test, result: 1.4)
         self.testInterpreter("f", data: test, result: 2.5)
@@ -46,7 +46,7 @@ final class MirrorTests: XCTestCase {
         struct TestArray {
             let a: [Int]
         }
-        let test = TestArray(a: [1,2,3,4,5])
+        let test = TestArray(a: [1, 2, 3, 4, 5])
         self.testInterpreter("a[2]", data: test, result: 3)
         self.testInterpreter("a[-2]", data: test, result: 4)
         self.testInterpreter("a[1]", data: test, result: 2)
@@ -57,6 +57,7 @@ final class MirrorTests: XCTestCase {
             struct TestSubObject {
                 let a: String
             }
+
             let sub: TestSubObject
         }
         let test = TestObject(sub: .init(a: "hello"))


### PR DESCRIPTION
Instead of parsing whole JSON object to calculate types, parse only parts that are going to be processed.
`JSONVariable` now stores a `[Any]` for an array and `[String: Any]` for an object